### PR TITLE
bump next from 16.1.5 to 16.2.9

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.554.0",
-    "next": "16.1.5",
+    "next": "16.2.9",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## SafeBump: next 16.1.5 → 16.2.9

Updates `next` (prod) in `frontend` from `16.1.5` to `16.2.9`.

### 🔧 Resolution (F1)
- Update type: **minor**
- Range edit only (lockfile resolution & sandbox verification: _pending M1_)

### ✅ Safety (F2)
- _pending M2_ — malware / advisory / cooldown checks not yet enforced

### 📋 Impact (F3)
- _pending M3_ — breaking-change & usage mapping not yet attached

### Links
- [npm](https://www.npmjs.com/package/next)
- [next@16.2.9](https://www.npmjs.com/package/next/v/16.2.9)

---
🤖 Generated with [SafeBump](https://github.com/Pirikara/SafeBump)