### PR TITLE
bump langchain-community from 0.4.1 to 0.4.2

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,7 @@ celery[redis]>=5.4.0
 
 # --- LangChain / RAG ---
 langchain==1.0.8
-langchain-community==0.4.1
+langchain-community==0.4.2
 langchain-huggingface>=0.0.6
 sentence-transformers>=2.2.2
 pyyaml>=6.0.1


### PR DESCRIPTION
## SafeBump: langchain-community 0.4.1 → 0.4.2  ·  Risk: low

### 🔧 Resolution (F1)
- ✅ resolved directly; verified resolvable via uv (no package code executed)
- changes:
  - `langchain-community`: `==0.4.1` → `==0.4.2`

### ✅ Safety (F2)
- ✅ no known OSV advisories; cooldown passed

### 📋 Impact (F3)
- **Risk: low** — patch version bump; used in 1 file
- used in **1 file(s)**, 2 import site(s):
  - `backend/app/services/vector_db/manager.py:25` (import)
  - `backend/app/services/vector_db/manager.py:26` (import)

### ⏳ Deprecation (F4)
- ✅ not deprecated; actively maintained

### Links
- [PyPI](https://pypi.org/project/langchain-community/) · [langchain-community 0.4.2](https://pypi.org/project/langchain-community/0.4.2/)

---
🤖 Generated with [SafeBump](https://github.com/Pirikara/SafeBump)